### PR TITLE
extra sudo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ rm -rf taky-data/
 apt-get update
 apt-get upgrade -y
 apt-get install zip -y
-sudo apt-get install unzip -y
+apt-get install unzip -y
 apt-get install docker -y
 apt-get install docker-compose -y
 cd /root/ 


### PR DESCRIPTION
I would prefer to do all of this as a non-root user but in the meantime, you used `sudo` only to `apt-get install unzip -y`. Separately, why aren't you stacking your installs into one command? Are you keeping them on one line each for readability?